### PR TITLE
Add topic extraction for memory entries

### DIFF
--- a/scripts/memory_manager.py
+++ b/scripts/memory_manager.py
@@ -2,6 +2,37 @@ import json
 from pathlib import Path
 from uuid import uuid4
 from datetime import datetime
+from keybert import KeyBERT
+import re
+from collections import Counter
+from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS
+
+# KeyBERT model will be loaded lazily to avoid import-time overhead.
+_kw_model = None
+
+
+def extract_topic(text: str) -> str:
+    """Return the top keyword as a simple topic label."""
+    global _kw_model
+    if _kw_model is None:
+        try:
+            _kw_model = KeyBERT("all-MiniLM-L6-v2")
+        except Exception:
+            _kw_model = False
+    if _kw_model:
+        try:
+            keywords = _kw_model.extract_keywords(text, stop_words="english", top_n=1)
+            if keywords:
+                return keywords[0][0]
+        except Exception:
+            pass
+
+    # Fallback keyword extraction using term frequency
+    words = re.findall(r"\b[a-zA-Z]{3,}\b", text.lower())
+    words = [w for w in words if w not in ENGLISH_STOP_WORDS]
+    if not words:
+        return ""
+    return Counter(words).most_common(1)[0][0]
 
 MEMORY_FILE = Path("data/memory/memory.json")
 
@@ -17,6 +48,9 @@ def load_log():
 
 
 def add_entry(question, answer, summary, impact_score=5):
+    topic_text = f"{question} {summary} {answer}"
+    topic = extract_topic(topic_text)
+
     entry = {
         "id": str(uuid4()),
         "timestamp": datetime.utcnow().isoformat(),
@@ -24,6 +58,7 @@ def add_entry(question, answer, summary, impact_score=5):
         "answer": answer,
         "summary": summary,
         "impact_score": impact_score,
+        "topic": topic,
     }
     log = load_log()
     log.append(entry)


### PR DESCRIPTION
## Summary
- extract a topic from each Q&A pair in the memory manager
- fallback to a simple term-frequency method when KeyBERT fails

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile scripts/memory_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68427a5d7a88832a8aad4372e2678d44