### PR TITLE
Add simple web frontend

### DIFF
--- a/app_web.py
+++ b/app_web.py
@@ -1,0 +1,57 @@
+from flask import Flask, request, jsonify, send_from_directory
+from pathlib import Path
+import re
+import json
+
+from scripts.pdf_parser import parse_pdf_to_chunks, save_chunks_to_json
+from scripts.rag_engine import get_relevant_chunks
+from scripts.ollama_interface import query_llama
+from scripts.memory_manager import add_entry, load_log
+
+PDF_DIR = Path('data/pdfs')
+
+app = Flask(__name__, static_folder='.')
+
+@app.route('/')
+def index():
+    return send_from_directory('.', 'frontend.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_pdf():
+    if 'pdf' not in request.files:
+        return jsonify({'error': 'no file'}), 400
+    f = request.files['pdf']
+    PDF_DIR.mkdir(parents=True, exist_ok=True)
+    path = PDF_DIR / f.filename
+    f.save(path)
+    chunks = parse_pdf_to_chunks(path)
+    save_chunks_to_json(f.filename, chunks)
+    return jsonify({'status': 'ok', 'chunks': len(chunks)})
+
+@app.route('/ask', methods=['POST'])
+def ask_question():
+    data = request.get_json() or {}
+    question = data.get('question')
+    if not question:
+        return jsonify({'error': 'no question'}), 400
+    chunks = get_relevant_chunks(question)
+    context = "\n\n".join([c['text'] for c in chunks])
+    response = query_llama(question, system_context=context)
+    summary = query_llama(f"Summarize this answer in 1 sentence:\n{response}")
+    score_str = query_llama(
+        f"Rate the importance of this answer on a scale from 1 to 10:\n{response}"
+    )
+    match = re.search(r'\b([1-9]|10)\b', score_str)
+    try:
+        impact = int(match.group(1)) if match else 5
+    except Exception:
+        impact = 5
+    add_entry(question, response, summary, impact)
+    return jsonify({'answer': response, 'impact': impact})
+
+@app.route('/memory')
+def memory():
+    return jsonify(load_log())
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend.html
+++ b/frontend.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PDF Assistant</title>
+<style>
+  body {
+    font-family: Arial, sans-serif;
+    background:#f6f8fa;
+    padding:20px;
+    max-width:600px;
+    margin:auto;
+  }
+  h1 {
+    text-align:center;
+  }
+  button, input[type="file"], input[type="text"] {
+    width:100%;
+    padding:10px;
+    margin-top:8px;
+    font-size:1.1em;
+  }
+  #result {
+    background:#fff;
+    padding:10px;
+    border-radius:4px;
+    margin-top:20px;
+    min-height:60px;
+  }
+  #memoryList {
+    margin-top:20px;
+  }
+  .memory-item {
+    padding:8px;
+    border-bottom:1px solid #ddd;
+  }
+</style>
+</head>
+<body>
+<h1>Research Assistant</h1>
+<form id="uploadForm">
+  <input type="file" id="pdfFile" accept="application/pdf" required>
+  <button type="submit">Upload PDF</button>
+</form>
+
+<form id="askForm">
+  <input type="text" id="question" placeholder="Ask a question" required>
+  <button type="submit">Ask</button>
+</form>
+
+<div id="result"></div>
+<div id="memoryList"></div>
+
+<script>
+async function loadMemory() {
+  try {
+    const r = await fetch('/memory');
+    const entries = await r.json();
+    const list = document.getElementById('memoryList');
+    list.innerHTML = '';
+    entries.forEach(e => {
+      const div = document.createElement('div');
+      div.className = 'memory-item';
+      div.textContent = `${e.question} - Score ${e.impact_score}`;
+      list.prepend(div);
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+document.getElementById('uploadForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fileInput = document.getElementById('pdfFile');
+  if (!fileInput.files.length) return;
+  const formData = new FormData();
+  formData.append('pdf', fileInput.files[0]);
+  const res = await fetch('/upload', {method:'POST', body:formData});
+  const data = await res.json();
+  alert('Uploaded ' + (data.chunks || 0) + ' chunks');
+  loadMemory();
+});
+
+document.getElementById('askForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const question = document.getElementById('question').value;
+  const res = await fetch('/ask', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({question})
+  });
+  const data = await res.json();
+  document.getElementById('result').textContent = `${data.answer}\nImpact: ${data.impact}`;
+  const div = document.createElement('div');
+  div.className = 'memory-item';
+  div.textContent = `${question} - Score ${data.impact}`;
+  document.getElementById('memoryList').prepend(div);
+});
+
+loadMemory();
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sentence-transformers
 scikit-learn
 matplotlib
 keybert
+flask


### PR DESCRIPTION
## Summary
- add an HTML/JS page to upload PDFs, send questions and list memory
- implement a minimal Flask app exposing `/upload`, `/ask` and `/memory`
- include Flask in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68430ef6ab88832a952601aa234a82d8